### PR TITLE
Fix php_user_filter::filter interface: allow null value for `$consumed`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,1 +1,6 @@
 # Upgrade Notes
+
+### 1.1.1
+Fix php_user_filter::filter interface: allow null value for `$consumed`
+### 1.1.0
+Upgrade License

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,6 @@ parameters:
     symfony:
         containerXmlPath: %currentWorkingDirectory%/var/cache/test/TestKernelTestDebugContainer.xml
         constantHassers: false
+    ignoreErrors:
+        - '#Call to static method buildForEntity\(\) on an unknown class I18nBundle\\Builder\\RouteParameterBuilder\.#'
+        - '#Parameter \&\$consumed by-ref type of method SecureStorageBundle\\Encrypter\\OpenSslEncrypter::filter\(\) expects int, int\|null given\.#'

--- a/src/Encrypter/OpenSslEncrypter.php
+++ b/src/Encrypter/OpenSslEncrypter.php
@@ -189,7 +189,7 @@ class OpenSslEncrypter extends php_user_filter implements EncrypterInterface
         return $processed;
     }
 
-    private function handleIv($in, $out, int &$consumed): void
+    private function handleIv($in, $out, ?int &$consumed): void
     {
         if ($this->iv !== null) {
             return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

